### PR TITLE
fix: removing ax.whenMissingSlot(..).for(intentName)

### DIFF
--- a/packages/alexa/src/blocks/builders/WhenSlotNotFilledBlockBuilder.ts
+++ b/packages/alexa/src/blocks/builders/WhenSlotNotFilledBlockBuilder.ts
@@ -1,20 +1,13 @@
 import { IntentRequest } from "ask-sdk-model";
-import { Context } from "mustache";
 import { AlexaBlock, AlexaBuilderContext, AlexaDialogContext, AlexaEvent, WhenSlotNotFilledBlock } from "../../models";
 
 export class WhenSlotNotFilledBlockBuilder {
   private _slotName: string;
-  private _intentName?: string;
   private _thenBlock?: AlexaBlock;
   private _otherwiseBlock?: AlexaBlock;
 
   constructor(name: string) {
     this._slotName = name;
-  }
-
-  for(intentName: string) {
-    this._intentName = intentName;
-    return this;
   }
 
   then(block: AlexaBlock) {
@@ -39,7 +32,6 @@ export class WhenSlotNotFilledBlockBuilder {
     return {
       type: "WhenSlotNotFilledBlock",
       name: this._slotName,
-      intentName: this._intentName,
       then: this._thenBlock,
       otherwise: this._otherwiseBlock,
       execute: this._executor,
@@ -50,11 +42,6 @@ export class WhenSlotNotFilledBlockBuilder {
   private _executor = (context: AlexaDialogContext, event: AlexaEvent) => {
     let request = <IntentRequest>event.currentRequest.request;
     if (request.type !== "IntentRequest") return;
-
-    // if intent name is provided but request doesn't match the intent name
-    if (this._intentName && request.intent.name !== this._intentName) {
-      this._otherwiseBlock?.execute(context, event);
-    }
 
     let slots = request.intent.slots;
     if (slots && slots[this._slotName] && !slots[this._slotName].value) {

--- a/packages/alexa/src/models/index.ts
+++ b/packages/alexa/src/models/index.ts
@@ -85,7 +85,6 @@ export interface SlotTypeBlock extends AlexaBlock {
 export interface WhenSlotNotFilledBlock extends AlexaBlock {
   type: "WhenSlotNotFilledBlock";
   name: string;
-  intentName?: string;
   then: AlexaBlock;
   otherwise?: AlexaBlock;
 }

--- a/packages/alexa/test/blocks/builders/WhenSlotNotFilledBlockBuilder.test.ts
+++ b/packages/alexa/test/blocks/builders/WhenSlotNotFilledBlockBuilder.test.ts
@@ -103,27 +103,4 @@ describe("WhenSlotNotFilledBlockBuilder", () => {
 
     expect(dialogContext.currentResponse.response.outputSpeech).to.be.undefined;
   });
-
-  it("should not invoke thenBlock if slot is present in the intent request but intent is mismatch", async () => {
-    let event: AlexaEvent = { currentRequest: helloIntentRequest };
-    let dialogContext: AlexaDialogContext = {
-      platformState: { globalState: {}, currentStateName: "" },
-      currentResponse: {
-        version: "1.0",
-        response: JSON.parse("{}"),
-      },
-    };
-
-    let promptMsg = "Hello world";
-    let b = new WhenSlotNotFilledBlockBuilder("city")
-      .for("WeatherIntent")
-      .then(ax.say("bla bla"))
-      .otherwise(ax.say(promptMsg))
-      .build();
-    b.execute(dialogContext, event);
-
-    expect(dialogContext.currentResponse.response.outputSpeech).to.not.be.undefined;
-    let s = <ui.SsmlOutputSpeech>dialogContext.currentResponse.response.outputSpeech;
-    expect(s.ssml).equals(`<speak>${promptMsg}</speak>`);
-  });
 });


### PR DESCRIPTION
Removing the `.for(intentName)` because it's not needed, we will let users chain the intent with
this `whenMissingSlot()` block using either the `whenUserSays()` or `whenIntentName()` blocks.

re #19